### PR TITLE
Enable ldo4 for both ucm and iot-gate

### DIFF
--- a/board/compulab/plat/imx8mp/board/board.c
+++ b/board/compulab/plat/imx8mp/board/board.c
@@ -631,7 +631,7 @@ static int mx8_rgmii_rework(struct phy_device *phydev)
 #include <common.h>
 #include <command.h>
 
-#ifdef TARGET_UCM_IMX8M_PLUS
+#if defined(CONFIG_TARGET_UCM_IMX8M_PLUS) || defined(CONFIG_TARGET_IOT_GATE_IMX8PLUS)
 static char ldo4_help_text[] =
 	"value[8-33] - set 0x24 register value; voltage range: [0.80-3.30]\n"
 	"ldo4 value[0] - disable ldo4\n";

--- a/board/compulab/plat/imx8mp/spl/spl.c
+++ b/board/compulab/plat/imx8mp/spl/spl.c
@@ -166,7 +166,7 @@ int board_mmc_getcd(struct mmc *mmc)
 }
 
 #if CONFIG_IS_ENABLED(DM_PMIC_PCA9450)
-#ifdef TARGET_UCM_IMX8M_PLUS
+#if defined(CONFIG_TARGET_UCM_IMX8M_PLUS) || defined(CONFIG_TARGET_IOT_GATE_IMX8PLUS)
 /* Forward declarations */
 u8 cl_eeprom_get_ldo4(void);
 static void power_init_ldo4(struct udevice *dev) {


### PR DESCRIPTION
Took a bit of time to find out why Ethernet 0 was not working with latest Compulab changes 😞. Will send the change upstream to Compulab also 👍🏻 